### PR TITLE
Fix compatibility with Ruby 2.x + fix main usability pitfalls/problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The proxy target should be set as an internal server in nginx, so that it can on
 The following variables are optional:
 
 * AUTH\_DOMAIN: the local address of this authentication app (change if not 'localhost')
+* COOKIE\_SECRET: a random secret will be generated at runtime if this is not set. If you need to avoid reauthenticating each time okta-auth-proxy is restarted for some reason, set this to a fixed value.
 * DEBUG: set this to anything to debug logging
 
 **Note:** Ensure the protocol in okta matches the protocol of your app (http/https)

--- a/lib/okta-auth-proxy/app.rb
+++ b/lib/okta-auth-proxy/app.rb
@@ -11,6 +11,8 @@ module OktaAuthProxy
       send verb, '/*' do
         pass if request.host == (ENV['AUTH_DOMAIN'] || 'localhost')
         pass if request.path == '/auth/saml/callback'
+        pass if request.path == '/auth/failure'
+
         protected!
         # If authorized, serve request
         if url = authorized?(request.host)

--- a/lib/okta-auth-proxy/app.rb
+++ b/lib/okta-auth-proxy/app.rb
@@ -1,9 +1,17 @@
 require 'sinatra'
+require 'logger'
 require 'okta-auth-proxy/auth'
 
 module OktaAuthProxy
   class ProxyApp < Sinatra::Base
     register OktaAuthProxy::OktaAuth
+
+    def initialize
+      super
+      @logger =  Logger.new(STDOUT)
+      @logger.progname = 'okta-auth-proxy'
+      @logger
+    end
 
      # Block that is called back when authentication is successful
     [:get, :post, :put, :head, :delete, :options, :patch, :link, :unlink].each do |verb|
@@ -12,6 +20,11 @@ module OktaAuthProxy
         pass if request.host == (ENV['AUTH_DOMAIN'] || 'localhost')
         pass if request.path == '/auth/saml/callback'
         pass if request.path == '/auth/failure'
+
+        if request.host != OktaAuth::COOKIE_DOMAIN
+          @logger.warn "Request host (#{request.host}) and COOKIE_DOMAIN (#{OktaAuth::COOKIE_DOMAIN}) " +
+            "do not match. Cookies will not be set or readable. Check your COOKIE_DOMAIN value."
+        end
 
         protected!
         # If authorized, serve request

--- a/lib/okta-auth-proxy/auth.rb
+++ b/lib/okta-auth-proxy/auth.rb
@@ -1,6 +1,7 @@
 require 'sinatra/base'
 require 'omniauth'
 require 'omniauth-saml'
+require 'securerandom'
 
 module OktaAuthProxy
   module OktaAuth
@@ -22,8 +23,9 @@ module OktaAuthProxy
 
     def self.registered(app)
       app.helpers OktaAuthProxy::OktaAuth::AuthHelpers
+
       # Use a wildcard cookie to achieve single sign-on for all subdomains
-      app.use Rack::Session::Cookie, secret: ENV['COOKIE_SECRET'] || 'replaceme',
+      app.use Rack::Session::Cookie, secret: ENV['COOKIE_SECRET'] || SecureRandom.random_bytes(24),
                                      domain: ENV['COOKIE_DOMAIN'] || 'localhost'
       app.use OmniAuth::Builder do
         provider :saml,

--- a/lib/okta-auth-proxy/auth.rb
+++ b/lib/okta-auth-proxy/auth.rb
@@ -6,6 +6,8 @@ require 'securerandom'
 module OktaAuthProxy
   module OktaAuth
 
+    COOKIE_DOMAIN = ENV['COOKIE_DOMAIN'] || 'localhost'
+
     module AuthHelpers
       def protected!
         return if authorized?(request.host)
@@ -26,7 +28,7 @@ module OktaAuthProxy
 
       # Use a wildcard cookie to achieve single sign-on for all subdomains
       app.use Rack::Session::Cookie, secret: ENV['COOKIE_SECRET'] || SecureRandom.random_bytes(24),
-                                     domain: ENV['COOKIE_DOMAIN'] || 'localhost'
+                                     domain: COOKIE_DOMAIN
       app.use OmniAuth::Builder do
         provider :saml,
         issuer:                             ENV['SSO_ISSUER'],

--- a/lib/okta-auth-proxy/server.rb
+++ b/lib/okta-auth-proxy/server.rb
@@ -36,7 +36,6 @@ module OktaAuthProxy
     def init_sighandlers
       trap(:INT)  { 'Got interrupt'; EM.stop; exit }
       trap(:TERM) { 'Got term';      EM.stop; exit }
-      trap(:KILL) { 'Got kill';      EM.stop; exit }
     end
   end
 end


### PR DESCRIPTION
- Remove SIGKILL handler as this signal is not catchable (causes immediate crash under Ruby 2.x).
- Use a random cookie secret at runtime if not provided.
- Fix redirect/authentication loop when SAML transaction fails (`/auth/failure` endpoint not reachable)
- Add warning if current request host and COOKIE_DOMAIN differ, preventing cookies being written and endlessly redirecting through the auth process.

I can submit these as individual PRs if you prefer. There's also some readme and example updates that depend on these commits.